### PR TITLE
Use default=str when dumping rows to JSON

### DIFF
--- a/marshmallow_pyspark/schema.py
+++ b/marshmallow_pyspark/schema.py
@@ -72,7 +72,8 @@ class _RowValidator:
                     {
                         "row": data,
                         "errors": err.messages,
-                    }
+                    },
+                    default=str,
                 )
             }
 


### PR DESCRIPTION
- Closes #4.