### PR TITLE
update marshmallow-oneofschema dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
         python_requires='>=3.4',
         install_requires=[
             'marshmallow~=3.2',
-            'marshmallow-oneofschema~=2.0',
+            'marshmallow-oneofschema~=3.0',
         ],
         extras_require={
             'dev': [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -451,7 +451,7 @@ def test_row_validator():
     class TestSchema(Schema):
         title = fields.Str()
         release_date = fields.Date()
-        timestamp = fields.Raw(spark_type=DateType())
+        timestamp = fields.Raw(metadata=dict(spark_type=DateType()))
 
     validator = _RowValidator(TestSchema(), DEFAULT_ERRORS_COLUMN, [])
     validated_data = [validator.validate_row(Row(**x)) for x in input_data]


### PR DESCRIPTION
This fixes:

 - the marshmallow-oneofschema dependency is now up to date with the latest version
 - a deprecation warning from some test logic

All tests are passing